### PR TITLE
Feat: Add Custom Period Range When Generating Report

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,21 @@ All content is inserted as plain text, which means:
 
 Future versions may implement automatic conversion between Markdown syntax and Google Docs formatting elements.
 
+### Converting Markdown to Formatted Text
+
+Before converting your Markdown to properly format text in Google Docs, ensure that the Markdown option is enabled:
+
+1. In Google Docs, navigate to **Tools** > **Preferences**.
+2. Check the option to **Enable Markdown**.
+3. Click **OK** to save your changes.
+
+After enabling Markdown, follow these steps to convert your plain Markdown to formatted text:
+
+1. In Google Docs, press **Ctrl + A** to select all content
+2. Press **Ctrl + X** to cut the content
+3. Right-click on the empty document area and select **Paste as Markdown**
+
+
 ## Custom Date Ranges
 
 The weekly report generator supports custom date ranges, allowing you to generate reports for specific periods instead of just the current week.
@@ -213,19 +228,6 @@ REPORT_END_DATE: str = None
 
 If invalid date formats are provided, the system will display an error message and instructions to fix the format.
 
-### Converting Markdown to Formatted Text
-
-Before converting your Markdown to properly format text in Google Docs, ensure that the Markdown option is enabled:
-
-1. In Google Docs, navigate to **Tools** > **Preferences**.
-2. Check the option to **Enable Markdown**.
-3. Click **OK** to save your changes.
-
-After enabling Markdown, follow these steps to convert your plain Markdown to formatted text:
-
-1. In Google Docs, press **Ctrl + A** to select all content
-2. Press **Ctrl + X** to cut the content
-3. Right-click on the empty document area and select **Paste as Markdown**
 
 ## Report Structure
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,39 @@ All content is inserted as plain text, which means:
 
 Future versions may implement automatic conversion between Markdown syntax and Google Docs formatting elements.
 
+## Custom Date Ranges
+
+The weekly report generator supports custom date ranges, allowing you to generate reports for specific periods instead of just the current week.
+
+### Configuration
+
+To set a custom date range, edit the `REPORT_START_DATE` and `REPORT_END_DATE` variables in [`core/user_data.py`](https://github.com/luvnyen/gdp-labs-weekly-report-generator/blob/main/core/user_data.py):
+
+```python
+# Example: Generate report for January 2025
+REPORT_START_DATE: str = "2025-01-01"
+REPORT_END_DATE: str = "2025-01-31"
+
+# Example: Generate report for a specific week
+REPORT_START_DATE: str = "2025-01-06"
+REPORT_END_DATE: str = "2025-01-10"
+
+# Example: Use current week (default behavior)
+REPORT_START_DATE: str = None
+REPORT_END_DATE: str = None
+```
+
+### Date Format
+
+- Use the format: `YYYY-MM-DD` (e.g., "2025-01-01")
+- Both dates are inclusive
+- Start date must be before or equal to end date
+- If only one date is provided, the system will use the current week for the missing date
+
+### Error Handling
+
+If invalid date formats are provided, the system will display an error message and instructions to fix the format.
+
 ### Converting Markdown to Formatted Text
 
 Before converting your Markdown to properly format text in Google Docs, ensure that the Markdown option is enabled:

--- a/core/services/google_forms_service.py
+++ b/core/services/google_forms_service.py
@@ -18,11 +18,15 @@ from utils.date_time_util import ordinal, format_time
 FORMS_RECEIPT_EMAIL = "forms-receipts-noreply@google.com"
 
 
-def get_forms_filled_this_week() -> List[Dict[str, Any]]:
-    """Retrieve Google Forms submissions from the current week.
+def get_forms_filled_for_date_range(start_date: datetime.date, end_date: datetime.date) -> List[Dict[str, Any]]:
+    """Retrieve Google Forms submissions from a specified date range.
 
-    Fetches emails from Google Forms receipt address since the start of the
-    current week and extracts form submission details.
+    Fetches emails from Google Forms receipt address within the specified date range
+    and extracts form submission details.
+
+    Args:
+        start_date: Start date for the form submissions range
+        end_date: End date for the form submissions range
 
     Returns:
         List[Dict[str, Any]]: List of form submissions with structure:
@@ -33,11 +37,10 @@ def get_forms_filled_this_week() -> List[Dict[str, Any]]:
     """
     service = get_google_service('gmail', 'v1')
 
-    today = datetime.now(TIMEZONE)
-    start_of_week = today - timedelta(days=today.weekday())
-    start_of_week = start_of_week.replace(hour=0, minute=0, second=0, microsecond=0)
+    start_datetime = datetime.combine(start_date, datetime.min.time(), tzinfo=TIMEZONE)
+    end_datetime = datetime.combine(end_date, datetime.max.time(), tzinfo=TIMEZONE)
 
-    query = f"from:{FORMS_RECEIPT_EMAIL} after:{start_of_week.strftime('%Y/%m/%d')}"
+    query = f"from:{FORMS_RECEIPT_EMAIL} after:{start_datetime.strftime('%Y/%m/%d')} before:{end_datetime.strftime('%Y/%m/%d')}"
     results = service.users().messages().list(userId='me', q=query).execute()
     messages = results.get('messages', [])
 
@@ -54,14 +57,36 @@ def get_forms_filled_this_week() -> List[Dict[str, Any]]:
                      .astimezone(TIMEZONE)
                      .replace(second=0, microsecond=0))
 
-        form_title = subject.replace("Response submitted:", "").strip()
+        # Filter by the actual submission date
+        if start_datetime <= timestamp <= end_datetime:
+            form_title = subject.replace("Response submitted:", "").strip()
 
-        filled_forms.append({
-            'title': form_title,
-            'timestamp': timestamp
-        })
+            filled_forms.append({
+                'title': form_title,
+                'timestamp': timestamp
+            })
 
     return filled_forms
+
+
+def get_forms_filled_this_week() -> List[Dict[str, Any]]:
+    """Retrieve Google Forms submissions from the current week.
+
+    Fetches emails from Google Forms receipt address since the start of the
+    current week and extracts form submission details.
+
+    Returns:
+        List[Dict[str, Any]]: List of form submissions with structure:
+            {
+                'title': str (form title),
+                'timestamp': datetime (submission time in configured timezone)
+            }
+    """
+    today = datetime.now(TIMEZONE)
+    start_of_week = today - timedelta(days=today.weekday())
+    end_of_week = start_of_week + timedelta(days=6)
+    
+    return get_forms_filled_for_date_range(start_of_week.date(), end_of_week.date())
 
 
 def format_filled_forms(filled_forms: List[Dict[str, Any]]) -> List[str]:
@@ -82,6 +107,22 @@ def format_filled_forms(filled_forms: List[Dict[str, Any]]) -> List[str]:
         formatted_time = format_time(timestamp)
         formatted_forms.append(f"{form['title']} (submitted on {formatted_date} at {formatted_time})")
     return formatted_forms
+
+
+def get_forms_filled_for_date_range_formatted(start_date: datetime.date, end_date: datetime.date) -> List[str]:
+    """Get a formatted list of forms submitted within a specified date range.
+
+    Convenience function that combines retrieval and formatting of form submissions.
+
+    Args:
+        start_date: Start date for the form submissions range
+        end_date: End date for the form submissions range
+
+    Returns:
+        List[str]: Formatted strings describing form submissions
+    """
+    filled_forms = get_forms_filled_for_date_range(start_date, end_date)
+    return format_filled_forms(filled_forms)
 
 
 def get_this_week_filled_forms_formatted() -> List[str]:

--- a/core/user_data.py
+++ b/core/user_data.py
@@ -67,5 +67,5 @@ Examples:
 - REPORT_END_DATE = "2025-01-31"    # Report until January 31st, 2025
 - REPORT_START_DATE = None          # Use current week Monday
 - REPORT_END_DATE = None            # Use current week Friday"""
-REPORT_START_DATE: str = None
-REPORT_END_DATE: str = None
+REPORT_START_DATE: Optional[str] = None
+REPORT_END_DATE: Optional[str] = None

--- a/core/user_data.py
+++ b/core/user_data.py
@@ -35,7 +35,7 @@ OMTM: list[str] = [
     "OMTM 1",
 ]
 
-NEXT_STEPS = [
+NEXT_STEPS: list[str] = [
     "Next step 1",
 ]
 
@@ -47,7 +47,7 @@ Examples:
 - [Article Title](https://example.com)
 - [Video Title](https://youtube.com/watch?v=123)
 """
-LEARNING = [
+LEARNING: list[str] = [
     "[O'Reilly Media] [Clean Architecture: A Craftsman's Guide to Software Structure and Design](https://www.oreilly.com/library/view/clean-architecture-a/9780134494272/) by Robert C. Martin (Chapter 26/34)",
 ]
 
@@ -57,4 +57,15 @@ List of meeting titles to be excluded from the weekly report, even if they exist
 These meetings are typically reminders or administrative tasks that do not need to be reflected
 in productivity reports or summaries.
 """
-EXCLUDED_MEETINGS = []
+EXCLUDED_MEETINGS: list[str] = []
+
+"""Report period configuration. Set these variables to specify a custom date range for the weekly report.
+If not set or set to None, the system will use the current week (Monday to Friday).
+Format: YYYY-MM-DD (e.g., "2025-01-01")
+Examples:
+- REPORT_START_DATE = "2025-01-01"  # Report from January 1st, 2025
+- REPORT_END_DATE = "2025-01-31"    # Report until January 31st, 2025
+- REPORT_START_DATE = None          # Use current week Monday
+- REPORT_END_DATE = None            # Use current week Friday"""
+REPORT_START_DATE: str = None
+REPORT_END_DATE: str = None

--- a/utils/date_time_util.py
+++ b/utils/date_time_util.py
@@ -55,6 +55,36 @@ def format_duration(seconds: Union[int, float]) -> str:
     return f"{hours:.1f}h"
 
 
+def format_weekdays_with_dates_for_period(days: List[int], start_date: datetime.date, end_date: datetime.date) -> str:
+    """
+    Format specified weekdays (by number) with their corresponding dates in a custom period.
+
+    Args:
+        days: List of weekdays as integers (1=Monday, ..., 5=Friday)
+        start_date: Start date of the period
+        end_date: End date of the period
+
+    Returns:
+        A formatted string listing the given weekdays with full dates (e.g., "Monday, June 3rd, 2024").
+    """
+    formatted_days = []
+    day_names = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']
+
+    # Calculate the Monday of the start date's week
+    start_monday = start_date - datetime.timedelta(days=start_date.weekday())
+    
+    for day in days:
+        if 1 <= day <= 5:
+            # Calculate the date for this weekday in the period
+            date = start_monday + datetime.timedelta(days=day - 1)
+            
+            # Check if this date falls within our period
+            if start_date <= date <= end_date:
+                formatted_days.append(f"{day_names[day - 1]}, {date.strftime('%B')} {ordinal(date.day)}, {date.year}")
+
+    return format_bulleted_list(formatted_days, indent="  ")
+
+
 def format_weekdays_with_dates(days: List[int]) -> str:
     """
     Format specified weekdays (by number) with their corresponding dates in the current week.
@@ -66,16 +96,10 @@ def format_weekdays_with_dates(days: List[int]) -> str:
         A formatted string listing the given weekdays with full dates (e.g., "Monday, June 3rd, 2024").
     """
     today = datetime.date.today()
-    monday = today - datetime.timedelta(days=today.weekday())
-    formatted_days = []
-    day_names = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']
-
-    for day in days:
-        if 1 <= day <= 5:
-            date = monday + datetime.timedelta(days=day - 1)
-            formatted_days.append(f"{day_names[day - 1]}, {date.strftime('%B')} {ordinal(date.day)}, {date.year}")
-
-    return format_bulleted_list(formatted_days, indent="  ")
+    start_of_week = today - datetime.timedelta(days=today.weekday())
+    end_of_week = start_of_week + datetime.timedelta(days=4)  # Friday
+    
+    return format_weekdays_with_dates_for_period(days, start_of_week, end_of_week)
 
 
 def get_current_week_period() -> str:


### PR DESCRIPTION
## Desription
This pull request introduces support for **custom date ranges** in the weekly report generator, allowing users to specify report periods beyond the current week. **If not specified, it will use default value of current week**.

Key changes include updates to the `GitHubService`, Google Calendar, and Google Forms services, along with the addition of new configuration options for date ranges.

## Examples
I want to generate the report from 1st of January 2025 until 31st of January 2025
`REPORT_START_DATE = "2025-01-01" and REPORT_END_DATE = "2025-01-31"`

I want to generate the report from 1st of January 2025 until NOW
`REPORT_START_DATE = "2025-01-01" and REPORT_END_DATE = None`

## Details

### Custom Date Range Support
* **README.md**: Documented how to configure custom date ranges using `REPORT_START_DATE` and `REPORT_END_DATE` in `core/user_data.py`. Includes examples and error handling for invalid date formats.
* **`core/user_data.py`**: Added `REPORT_START_DATE` and `REPORT_END_DATE` variables for specifying custom report periods. Updated type annotations for `NEXT_STEPS`, `LEARNING`, and `EXCLUDED_MEETINGS`. [[1]](diffhunk://#diff-dab19553c3326d48f6b929f041378bae1cb64808d7c9b9850c86be9a7c48e54dL38-R38) [[2]](diffhunk://#diff-dab19553c3326d48f6b929f041378bae1cb64808d7c9b9850c86be9a7c48e54dL50-R50) [[3]](diffhunk://#diff-dab19553c3326d48f6b929f041378bae1cb64808d7c9b9850c86be9a7c48e54dL60-R71)

### GitHub Service Enhancements
* **`core/services/github_service.py`**: Updated methods to use `start_date` and `end_date` instead of hardcoded week calculations. Added date range support in `_get_pr_commits`, `_fetch_merged_prs`, `_fetch_repo_prs_and_commits`, `_did_user_interact_this_week`, and `_fetch_reviewed_prs`. [[1]](diffhunk://#diff-f4132b166a43a69dea8bcb257387b869e75c9c918828ce9c778d6eb40c68b22dL66-R101) [[2]](diffhunk://#diff-f4132b166a43a69dea8bcb257387b869e75c9c918828ce9c778d6eb40c68b22dL145-R155) [[3]](diffhunk://#diff-f4132b166a43a69dea8bcb257387b869e75c9c918828ce9c778d6eb40c68b22dL177-R187) [[4]](diffhunk://#diff-f4132b166a43a69dea8bcb257387b869e75c9c918828ce9c778d6eb40c68b22dL269-R279) [[5]](diffhunk://#diff-f4132b166a43a69dea8bcb257387b869e75c9c918828ce9c778d6eb40c68b22dL304-R314) [[6]](diffhunk://#diff-f4132b166a43a69dea8bcb257387b869e75c9c918828ce9c778d6eb40c68b22dL346-R356)

### Google Calendar Service Updates
* **`core/services/google_calendar_service.py`**: Replaced `get_events_for_week` with `get_events_for_date_range` and added `get_events_for_current_week` for backward compatibility. Updated logic to handle custom date ranges. [[1]](diffhunk://#diff-e66d8657d96e9dcffa655d2685549dc5872e984bf4b0216582a39381014ac2efL60-R73) [[2]](diffhunk://#diff-e66d8657d96e9dcffa655d2685549dc5872e984bf4b0216582a39381014ac2efL85-R95) [[3]](diffhunk://#diff-e66d8657d96e9dcffa655d2685549dc5872e984bf4b0216582a39381014ac2efR137-R165)

### Google Forms Service Updates
* **`core/services/google_forms_service.py`**: Replaced `get_forms_filled_this_week` with `get_forms_filled_for_date_range` and added `get_forms_filled_this_week` for backward compatibility. Introduced filtering by submission date within the specified range. [[1]](diffhunk://#diff-23e5b3061fce816e9ef89eb814045c7134a0e111f31a6ffebfbadec3b8359a16L21-R29) [[2]](diffhunk://#diff-23e5b3061fce816e9ef89eb814045c7134a0e111f31a6ffebfbadec3b8359a16L36-R43) [[3]](diffhunk://#diff-23e5b3061fce816e9ef89eb814045c7134a0e111f31a6ffebfbadec3b8359a16R60-R61) [[4]](diffhunk://#diff-23e5b3061fce816e9ef89eb814045c7134a0e111f31a6ffebfbadec3b8359a16R72-R91) [[5]](diffhunk://#diff-23e5b3061fce816e9ef89eb814045c7134a0e111f31a6ffebfbadec3b8359a16R112-R127)

### Weekly Report Generator Updates
* **`core/weekly_report_generator.py`**: Updated functions to accept `start_date` and `end_date` parameters. Modified `get_github_data`, `get_calendar_events`, and `get_this_week_filled_forms_formatted` to utilize the new date range functionality. [[1]](diffhunk://#diff-1685d8d3d46f01687c61ef90f30b3ed67d8796ad516fd4360016277133e133f1L18-R22) [[2]](diffhunk://#diff-1685d8d3d46f01687c61ef90f30b3ed67d8796ad516fd4360016277133e133f1L41-R46) [[3]](diffhunk://#diff-1685d8d3d46f01687c61ef90f30b3ed67d8796ad516fd4360016277133e133f1L60-R62) [[4]](diffhunk://#diff-1685d8d3d46f01687c61ef90f30b3ed67d8796ad516fd4360016277133e133f1L103-R110)