### PR TITLE
Fix error due to missing "submitted_at"

### DIFF
--- a/core/services/github_service.py
+++ b/core/services/github_service.py
@@ -307,7 +307,12 @@ class GitHubService:
         r = requests.get(url, headers=self.headers)
         if r.status_code == 200:
             for rev in r.json():
-                if rev["user"]["login"] == GITHUB_USERNAME and rev["submitted_at"] >= since_iso:
+                submitted_at = rev.get("submitted_at")
+                if (
+                    rev["user"]["login"] == GITHUB_USERNAME
+                    and submitted_at is not None
+                    and submitted_at >= since_iso
+                ):
                     return True
 
         url = (


### PR DESCRIPTION
### Error:
```
sandy.a.dewangga@gdpl-ltp-244 gdp-labs-weekly-report-generator % ./run.sh
📊 Weekly Report Generator
📅 Report period: 2025-07-07 to 2025-07-11

✅ Fetched PRs and commits
✅ Summarized GitHub accomplishments with LLM
✅ Fetched merged PRs
⠧ Fetching reviewed PRs
❌ Error: 'submitted_at'
Press Enter to close this window...
```

The error was caused by the code assuming every pull request review object from the GitHub API has a submitted_at field. In reality, some reviews (such as those in a "PENDING" state) do not have this field, which leads to a KeyError.

### Fix applied:
The code now safely accesses submitted_at using .get("submitted_at") and checks that it is not None before comparing it to the date. This prevents the error and ensures only submitted reviews are considered.