### PR TITLE
feat: add Google Calendar focus time exclusion feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,9 @@ GOOGLE_CLIENT_SECRET_FILE=
 GOOGLE_GEMINI_API_KEY=
 
 GROQ_API_KEY=
+
+
+# Google Calendar Focus Time Exclusion
+# Set to true to exclude focus time events from calendar reports (default: true)
+# Set to false to include focus time events in calendar reports
+GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME=true

--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,8 @@ GOOGLE_GEMINI_API_KEY=
 GROQ_API_KEY=
 
 
-# Google Calendar Focus Time Exclusion
-# Set to true to exclude focus time events from calendar reports (default: true)
-# Set to false to include focus time events in calendar reports
-GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME=true
+
+# Google Calendar Default Type Only
+# Set to true to only include default type events in calendar reports (default: true)
+# Set to false to include all event types in calendar reports
+GOOGLE_CALENDAR_ONLY_INCLUDE_DEFAULT_TYPE=true

--- a/config/config.py
+++ b/config/config.py
@@ -97,7 +97,8 @@ class ConfigManager:
             'SONARQUBE_COMPONENTS'
         }),
         ServiceType.GOOGLE_CALENDAR: ServiceRequirements({
-            'GOOGLE_CLIENT_SECRET_FILE'
+            'GOOGLE_CLIENT_SECRET_FILE',
+            'GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME'
         }),
         ServiceType.GOOGLE_FORMS: ServiceRequirements({
             'GOOGLE_CLIENT_SECRET_FILE'
@@ -128,6 +129,7 @@ class ConfigManager:
             'GITHUB_PERSONAL_ACCESS_TOKEN': os.getenv('GITHUB_PERSONAL_ACCESS_TOKEN'),
             'GITHUB_USERNAME': os.getenv('GITHUB_USERNAME'),
             'GOOGLE_CLIENT_SECRET_FILE': os.getenv('GOOGLE_CLIENT_SECRET_FILE'),
+            'GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME': os.getenv('GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME', 'true'),
             'GOOGLE_GEMINI_API_KEY': os.getenv('GOOGLE_GEMINI_API_KEY'),
             'GROQ_API_KEY': os.getenv('GROQ_API_KEY'),
             'REPOS': os.getenv('REPOS'),
@@ -286,6 +288,17 @@ class ConfigManager:
         """
         return self.env_vars.get('GROQ_API_KEY')
 
+    @property
+    def google_calendar_exclude_focus_time(self) -> bool:
+        """Get Google Calendar focus time exclusion setting.
+
+        Returns:
+            bool: True if focus time events should be excluded, False otherwise.
+                 Defaults to True if not set.
+        """
+        value = self.env_vars.get('GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME', 'true')
+        return value.lower() in ('true', '1', 'yes', 'on')
+
 
 def parse_sonarqube_components(components_str: str) -> List[SonarQubeComponent]:
     """Parse comma-separated SonarQube component string into component objects.
@@ -327,3 +340,4 @@ GOOGLE_CLIENT_SECRET_FILE = config_manager.google_client_secret_file
 SONARQUBE_COMPONENTS = parse_sonarqube_components(config_manager.env_vars.get('SONARQUBE_COMPONENTS', ''))
 GOOGLE_GEMINI_API_KEY = config_manager.gemini_api_key
 GROQ_API_KEY = config_manager.groq_api_key
+GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME = config_manager.google_calendar_exclude_focus_time

--- a/config/config.py
+++ b/config/config.py
@@ -98,7 +98,7 @@ class ConfigManager:
         }),
         ServiceType.GOOGLE_CALENDAR: ServiceRequirements({
             'GOOGLE_CLIENT_SECRET_FILE',
-            'GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME'
+            'GOOGLE_CALENDAR_ONLY_INCLUDE_DEFAULT_TYPE'
         }),
         ServiceType.GOOGLE_FORMS: ServiceRequirements({
             'GOOGLE_CLIENT_SECRET_FILE'
@@ -129,7 +129,7 @@ class ConfigManager:
             'GITHUB_PERSONAL_ACCESS_TOKEN': os.getenv('GITHUB_PERSONAL_ACCESS_TOKEN'),
             'GITHUB_USERNAME': os.getenv('GITHUB_USERNAME'),
             'GOOGLE_CLIENT_SECRET_FILE': os.getenv('GOOGLE_CLIENT_SECRET_FILE'),
-            'GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME': os.getenv('GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME', 'true'),
+            'GOOGLE_CALENDAR_ONLY_INCLUDE_DEFAULT_TYPE': os.getenv('GOOGLE_CALENDAR_ONLY_INCLUDE_DEFAULT_TYPE', 'true'),
             'GOOGLE_GEMINI_API_KEY': os.getenv('GOOGLE_GEMINI_API_KEY'),
             'GROQ_API_KEY': os.getenv('GROQ_API_KEY'),
             'REPOS': os.getenv('REPOS'),
@@ -289,14 +289,14 @@ class ConfigManager:
         return self.env_vars.get('GROQ_API_KEY')
 
     @property
-    def google_calendar_exclude_focus_time(self) -> bool:
-        """Get Google Calendar focus time exclusion setting.
+    def google_calendar_only_include_default_type(self) -> bool:
+        """Get Google Calendar default type only inclusion setting.
 
         Returns:
-            bool: True if focus time events should be excluded, False otherwise.
+            bool: True if only default type events should be included, False otherwise.
                  Defaults to True if not set.
         """
-        value = self.env_vars.get('GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME', 'true')
+        value = self.env_vars.get('GOOGLE_CALENDAR_ONLY_INCLUDE_DEFAULT_TYPE', 'true')
         return value.lower() in ('true', '1', 'yes', 'on')
 
 
@@ -340,4 +340,4 @@ GOOGLE_CLIENT_SECRET_FILE = config_manager.google_client_secret_file
 SONARQUBE_COMPONENTS = parse_sonarqube_components(config_manager.env_vars.get('SONARQUBE_COMPONENTS', ''))
 GOOGLE_GEMINI_API_KEY = config_manager.gemini_api_key
 GROQ_API_KEY = config_manager.groq_api_key
-GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME = config_manager.google_calendar_exclude_focus_time
+GOOGLE_CALENDAR_ONLY_INCLUDE_DEFAULT_TYPE = config_manager.google_calendar_only_include_default_type

--- a/core/services/google_calendar_service.py
+++ b/core/services/google_calendar_service.py
@@ -14,7 +14,7 @@ from typing import List, Dict, Any
 
 from googleapiclient.errors import HttpError
 
-from config.config import TIMEZONE, GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME
+from config.config import TIMEZONE, GOOGLE_CALENDAR_ONLY_INCLUDE_DEFAULT_TYPE
 from core.services.google_service import get_google_service
 from core.user_data import EXCLUDED_MEETINGS
 from utils.date_time_util import ordinal, format_time
@@ -106,8 +106,7 @@ def get_events_for_week() -> List[str]:
             if event.get('eventType') == "workingLocation":
                 continue
 
-            # Exclude focus time events if configured to do so
-            if GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME and event.get('eventType') == "focusTime":
+            if GOOGLE_CALENDAR_ONLY_INCLUDE_DEFAULT_TYPE and event.get('eventType') != "default":
                 continue
 
             if event['summary'] in EXCLUDED_MEETINGS or not is_event_accepted_or_needs_action(event):

--- a/core/services/google_calendar_service.py
+++ b/core/services/google_calendar_service.py
@@ -14,7 +14,7 @@ from typing import List, Dict, Any
 
 from googleapiclient.errors import HttpError
 
-from config.config import TIMEZONE
+from config.config import TIMEZONE, GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME
 from core.services.google_service import get_google_service
 from core.user_data import EXCLUDED_MEETINGS
 from utils.date_time_util import ordinal, format_time
@@ -97,6 +97,7 @@ def get_events_for_week() -> List[str]:
             orderBy='startTime'
         ).execute()
         events = events_result.get('items', [])
+        excluded_focus_time_events = []
 
         if not events:
             return []
@@ -104,6 +105,10 @@ def get_events_for_week() -> List[str]:
         events_by_day = defaultdict(list)
         for event in events:
             if event.get('eventType') == "workingLocation":
+                continue
+
+            # Exclude focus time events if configured to do so
+            if GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME and event.get('eventType') == "focusTime":
                 continue
 
             if event['summary'] in EXCLUDED_MEETINGS or not is_event_accepted_or_needs_action(event):

--- a/core/services/google_calendar_service.py
+++ b/core/services/google_calendar_service.py
@@ -97,7 +97,6 @@ def get_events_for_week() -> List[str]:
             orderBy='startTime'
         ).execute()
         events = events_result.get('items', [])
-        excluded_focus_time_events = []
 
         if not events:
             return []


### PR DESCRIPTION
- Introduced `GOOGLE_CALENDAR_EXCLUDE_FOCUS_TIME` setting in `.env.example` to control focus time event inclusion in calendar reports.
- Updated `ConfigManager` to manage the new setting and provide a property for its retrieval.
- Modified `google_calendar_service` to exclude focus time events based on the new configuration, enhancing event filtering capabilities.